### PR TITLE
Some configurability for fractal background plus moving background

### DIFF
--- a/glass-theme/glass_theme/default.py
+++ b/glass-theme/glass_theme/default.py
@@ -51,6 +51,11 @@ class Theme(glass_theme.base.ThemeBase):
     define_BORDER_ACTIVE_COLOR_2 = "vec4(1., 1., 1., 1.)"
     define_BORDER_ACTIVE_COLOR_3 = "vec4(0., 0., 0., 1.)"
     define_BORDER_ACTIVE_COLOR_4 = "vec4(0., 0., 0., 1.)"
+
+    # See glass-theme/glass_theme/shaders/root/fragment.glsl for list of possible values
+    define_BACKGROUND_TYPE = 1
+    # 200 gives a much better picture, but is super slow in software...
+    define_FRACTAL_PRECISION = 10
     
     def linestrings2texture(self, f):
         coastline = json.load(f)

--- a/glass-theme/glass_theme/default.py
+++ b/glass-theme/glass_theme/default.py
@@ -56,6 +56,12 @@ class Theme(glass_theme.base.ThemeBase):
     define_BACKGROUND_TYPE = 1
     # 200 gives a much better picture, but is super slow in software...
     define_FRACTAL_PRECISION = 10
+    define_BACKGROUND_COLOR_TRANSFORM = ("transpose(mat4(" +
+                                         "-0.5, 0.0, 0.0, 1.0," +
+                                         "-0.5, 0.0, 0.0, 1.0," +
+                                         "-0.5, 0.0, 0.0, 1.0," +
+                                         "0.0, 0.0, 0.0, 1.0" +
+                                         "))")
     
     def linestrings2texture(self, f):
         coastline = json.load(f)

--- a/glass-theme/glass_theme/shaders/root/fragment.glsl
+++ b/glass-theme/glass_theme/shaders/root/fragment.glsl
@@ -10,58 +10,54 @@ out vec4 fragColor;
 vec2 iResolution = vec2(float(size.x), float(size.y));
 
 vec3 calc(in vec2 p) {
-/*	float w1 = 0.97 + 0.04*sin( 0.0 + 1.3*iGlobalTime*0.2 );
-	float w2 = 0.97 + 0.04*sin( 1.0 + 1.7*iGlobalTime*0.2 );
-	float w3 = 0.97 + 0.04*sin( 4.0 + 1.1*iGlobalTime*0.2 );
-	float w4 = 0.97 + 0.04*sin( 2.0 + 1.5*iGlobalTime*0.2 );
-	float w5 = 0.97 + 0.04*sin( 5.0 + 1.9*iGlobalTime*0.2 );
-*/
-	float w1, w2, w3, w4, w5;
-	w1 = w2 = w3 = w4 = w5 = 1.0;
-	w3 = w5 = 1.0;
+  float w1, w2, w3, w4, w5;
+  /*
+    w1 = 0.97 + 0.04*sin(0.0 + 1.3*iGlobalTime*0.2);
+    w2 = 0.97 + 0.04*sin(1.0 + 1.7*iGlobalTime*0.2);
+    w3 = 0.97 + 0.04*sin(4.0 + 1.1*iGlobalTime*0.2);
+    w4 = 0.97 + 0.04*sin(2.0 + 1.5*iGlobalTime*0.2);
+    w5 = 0.97 + 0.04*sin(5.0 + 1.9*iGlobalTime*0.2);
+  */
+  // w3 = w5 = 1.0;
+  w1 = w2 = w3 = w4 = w5 = 1.0;
 
-	float x = 0.5;
-	float h = 0.0;
-	for(int i = 0; i < FRACTAL_PRECISION; i++) {
-		x = w1*p.x*x*(1.0-x); h += log2(abs(w1*p.x*(1.0-2.0*x)));
-		x = w2*p.x*x*(1.0-x); h += log2(abs(w2*p.x*(1.0-2.0*x)));
-		x = w3*p.y*x*(1.0-x); h += log2(abs(w3*p.y*(1.0-2.0*x)));
-		x = w4*p.x*x*(1.0-x); h += log2(abs(w4*p.x*(1.0-2.0*x)));
-		x = w5*p.y*x*(1.0-x); h += log2(abs(w5*p.y*(1.0-2.0*x)));
-	}
-	h /= 200.0 * 5.0;
+  float x = 0.5;
+  float h = 0.0;
+  for (int i = 0; i < FRACTAL_PRECISION; i++) {
+    x = w1*p.x*x*(1.0-x); h += log2(abs(w1*p.x*(1.0-2.0*x)));
+    x = w2*p.x*x*(1.0-x); h += log2(abs(w2*p.x*(1.0-2.0*x)));
+    x = w3*p.y*x*(1.0-x); h += log2(abs(w3*p.y*(1.0-2.0*x)));
+    x = w4*p.x*x*(1.0-x); h += log2(abs(w4*p.x*(1.0-2.0*x)));
+    x = w5*p.y*x*(1.0-x); h += log2(abs(w5*p.y*(1.0-2.0*x)));
+  }
+  h /= 200.0 * 5.0;
 
-	vec3 col = vec3(0.0);
-	if(h < 0.0) {
-		h = abs(h);
-		col = vec3(0.5+0.5*sin(0.0+2.5*h),
-			0.5+0.5*sin(0.4+2.5*h),
-			0.5+0.5*sin(0.7+2.5*h) );
-		col *= vec3(1.1)*pow(h,0.25);
-	}
+  vec3 col = vec3(0.0);
+  if (h < 0.0) {
+    h = abs(h);
+    col = vec3(0.5+0.5*sin(0.0+2.5*h),
+               0.5+0.5*sin(0.4+2.5*h),
+               0.5+0.5*sin(0.7+2.5*h));
+    col *= vec3(1.1)*pow(h,0.25);
+  }
 
-	return col;
+  return col;
 }
 
 void main() {
-        vec3 col;
-        if (BACKGROUND_TYPE == 1) {
-#if 1
-	col = calc(3.0 + 1.0 * px_coord /
-							iResolution.xy);
-#else
-	col = calc( 3.0 + 1.0*(gl_FragCoord.xy+vec2(0.0,0.0)) /
-							iResolution.xy ) +
-	           calc( 3.0 + 1.0*(gl_FragCoord.xy+vec2(0.0,0.5)) /
-							iResolution.xy ) +
-	           calc( 3.0 + 1.0*(gl_FragCoord.xy+vec2(0.5,0.0)) /
-							iResolution.xy ) +
-	           calc( 3.0 + 1.0*(gl_FragCoord.xy+vec2(0.5,0.5)) /
-							iResolution.xy );
-	col /= 4.0;
-#endif
-        } else {
-                col = vec3(1., 1., 1.);
-        }
-	gl_FragColor = vec4(col, 1.0);
+  vec3 col;
+  if (BACKGROUND_TYPE == 1) {
+    #if 1
+      col = calc(3.0 + 1.0 * px_coord / iResolution.xy);
+    #else
+      col = calc(3.0 + 1.0*(gl_FragCoord.xy+vec2(0.0,0.0)) / iResolution.xy) +
+            calc(3.0 + 1.0*(gl_FragCoord.xy+vec2(0.0,0.5)) / iResolution.xy) +
+            calc(3.0 + 1.0*(gl_FragCoord.xy+vec2(0.5,0.0)) / iResolution.xy) +
+            calc(3.0 + 1.0*(gl_FragCoord.xy+vec2(0.5,0.5)) / iResolution.xy);
+      col /= 4.0;
+    #endif
+  } else {
+    col = vec3(1., 1., 1.);
+  }
+  gl_FragColor = vec4(col, 1.0);
 }

--- a/glass-theme/glass_theme/shaders/root/fragment.glsl
+++ b/glass-theme/glass_theme/shaders/root/fragment.glsl
@@ -1,7 +1,13 @@
 #version 330 core
 precision highp float;
 
+/* Copyright (c) 2020 alexkh
+   This code is available as a stand-alone fractal demo
+   at https://github.com/alexkh/gllyap
+*/
+
 uniform ivec2 size;
+uniform vec4 root_IG_VIEW_DESKTOP_VIEW;
 
 in vec2 px_coord;
 
@@ -46,9 +52,12 @@ vec3 calc(in vec2 p) {
 
 void main() {
   vec3 col;
+  vec2 coord = px_coord;
+  coord.y = iResolution.y - coord.y;
+  
   if (BACKGROUND_TYPE == 1) {
     #if 1
-      col = calc(3.0 + 1.0 * px_coord / iResolution.xy);
+      col = calc(3.0 + (1.0 * coord / iResolution.xy) * root_IG_VIEW_DESKTOP_VIEW.zw + root_IG_VIEW_DESKTOP_VIEW.xy);
     #else
       col = calc(3.0 + 1.0*(gl_FragCoord.xy+vec2(0.0,0.0)) / iResolution.xy) +
             calc(3.0 + 1.0*(gl_FragCoord.xy+vec2(0.0,0.5)) / iResolution.xy) +

--- a/glass-theme/glass_theme/shaders/root/fragment.glsl
+++ b/glass-theme/glass_theme/shaders/root/fragment.glsl
@@ -22,7 +22,7 @@ vec3 calc(in vec2 p) {
 
 	float x = 0.5;
 	float h = 0.0;
-	for(int i = 0; i < 200; i++) {
+	for(int i = 0; i < FRACTAL_PRECISION; i++) {
 		x = w1*p.x*x*(1.0-x); h += log2(abs(w1*p.x*(1.0-2.0*x)));
 		x = w2*p.x*x*(1.0-x); h += log2(abs(w2*p.x*(1.0-2.0*x)));
 		x = w3*p.y*x*(1.0-x); h += log2(abs(w3*p.y*(1.0-2.0*x)));
@@ -44,11 +44,13 @@ vec3 calc(in vec2 p) {
 }
 
 void main() {
+        vec3 col;
+        if (BACKGROUND_TYPE == 1) {
 #if 1
-	vec3 col = calc(3.0 + 1.0 * px_coord /
+	col = calc(3.0 + 1.0 * px_coord /
 							iResolution.xy);
 #else
-	vec3 col = calc( 3.0 + 1.0*(gl_FragCoord.xy+vec2(0.0,0.0)) /
+	col = calc( 3.0 + 1.0*(gl_FragCoord.xy+vec2(0.0,0.0)) /
 							iResolution.xy ) +
 	           calc( 3.0 + 1.0*(gl_FragCoord.xy+vec2(0.0,0.5)) /
 							iResolution.xy ) +
@@ -58,6 +60,8 @@ void main() {
 							iResolution.xy );
 	col /= 4.0;
 #endif
-
+        } else {
+                col = vec3(1., 1., 1.);
+        }
 	gl_FragColor = vec4(col, 1.0);
 }

--- a/glass-theme/glass_theme/shaders/root/fragment.glsl
+++ b/glass-theme/glass_theme/shaders/root/fragment.glsl
@@ -68,5 +68,5 @@ void main() {
   } else {
     col = vec3(1., 1., 1.);
   }
-  gl_FragColor = vec4(col, 1.0);
+  gl_FragColor = BACKGROUND_COLOR_TRANSFORM * vec4(col, 1.0);
 }


### PR DESCRIPTION
This allows you to turn on/off the fractal and set its CPU/GPU requirements in your ~/.config/glass/theme.json as well as define a color range:

    {
        "name": "glass_theme.default.Theme",
        "args": {
            "latlon": [70., 18.],
            "mode": "no_splash",
            "define_BACKGROUND_TYPE": 1,
            "define_FRACTAL_PRECISION": 10,
            "define_BACKGROUND_COLOR_TRANSFORM": "transpose(mat4(0.0, 0.0, 0.0, 1.0,  -0.5, 0.0, 0.0, 1.0,  -0.5, 0.0, 0.0, 1.0,  0.0, 0.0, 0.0, 1.0))"
        }
    }

In addition, this PR fixes the indentation to match the rest of the project, and makes the background move and zoom with the desktop.